### PR TITLE
ci: move Linux CI to self-hosted ARC (sized -4/-8)

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,5 @@
+self-hosted-runner:
+  # Self-hosted ARC runner labels (Actions Runner Controller on ever-k8s).
+  labels:
+    - ever-k8s-linux-x64-4
+    - ever-k8s-linux-x64-8

--- a/.github/workflows/pulumi.yml
+++ b/.github/workflows/pulumi.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   deploy:
     name: Update
-    runs-on: ever-k8s-linux-x64-4
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/pulumi.yml
+++ b/.github/workflows/pulumi.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   deploy:
     name: Update
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, ever-k8s-linux-x64-4]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/pulumi.yml
+++ b/.github/workflows/pulumi.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   deploy:
     name: Update
-    runs-on: [self-hosted, ever-k8s-linux-x64-4]
+    runs-on: ever-k8s-linux-x64-4
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
## Move Linux CI to sized self-hosted ARC runners

Repoints this repo's cloud-hosted Linux CI onto the self-hosted **ever-k8s** ARC runners (Actions Runner Controller on k8s workers), sized by job weight.

### Runner mapping applied
| Old label | New label |
|---|---|
| `ubuntu-latest` (default job) | `[self-hosted, ever-k8s-linux-x64-4]` |

### Job counts
- **-> ever-k8s-linux-x64-4:** 1 job (`deploy` / Update)
- **-> ever-k8s-linux-x64-8:** 0 jobs

There is a single workflow (`.github/workflows/pulumi.yml`) with one job, previously `ubuntu-latest`; it now targets the 4-vCPU ARC label. No 8-vCPU-class jobs exist here.

### Left on GitHub-hosted / unchanged (per policy)
- **CodeQL** jobs (`github/codeql-action`) — none present, but policy preserved.
- **macOS** (`cirruslabs/macos-*`), **Windows**, **ARM** (`*-arm`), and **16-core** (`ubuntu-latest-16-cores`) jobs — none present; would be left hosted.

### Also added
- `.github/actionlint.yaml` declaring both self-hosted labels (`ever-k8s-linux-x64-4`, `ever-k8s-linux-x64-8`) under `self-hosted-runner.labels` so actionlint recognizes them.

Fork-PR CI remains disabled (this workflow runs only on `push` to `master` and `workflow_dispatch`, never on `pull_request`).

Reviewable PR only — not auto-merged.
